### PR TITLE
Fix only delete service's own Consul kv tree

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
-FROM gliderlabs/alpine:3.2
+FROM alpine:3.5
 ENTRYPOINT ["/bin/registrator"]
 
 COPY . /go/src/github.com/gliderlabs/registrator
-RUN apk-install -t build-deps go git mercurial \
+RUN apk --no-cache add -t build-deps build-base go git \
 	&& cd /go/src/github.com/gliderlabs/registrator \
 	&& export GOPATH=/go \
+  && git config --global http.https://gopkg.in.followRedirects true \
 	&& go get \
-	&& go build -ldflags "-X main.Version $(cat VERSION)" -o /bin/registrator \
+	&& go build -ldflags "-X main.Version=$(cat VERSION)" -o /bin/registrator \
 	&& rm -rf /go \
 	&& apk del --purge build-deps

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,9 +1,10 @@
-FROM gliderlabs/alpine:3.2
+FROM alpine:3.5
 CMD ["/bin/registrator"]
 
 ENV GOPATH /go
-RUN apk-install go git mercurial
+RUN apk --no-cache add build-base go git
 COPY . /go/src/github.com/gliderlabs/registrator
 RUN cd /go/src/github.com/gliderlabs/registrator \
+  && git config --global http.https://gopkg.in.followRedirects true \
 	&& go get \
-	&& go build -ldflags "-X main.Version dev" -o /bin/registrator
+	&& go build -ldflags "-X main.Version=dev" -o /bin/registrator

--- a/consulmeta/consulmeta.go
+++ b/consulmeta/consulmeta.go
@@ -120,7 +120,7 @@ func (r *ConsulMetaAdapter) Deregister(service *bridge.Service) error {
 	// Only remove KV data when there are no more services with the same name
 	var services, _, _ = r.client.Catalog().Service(service.Name, "", nil)
 	if len(services) == 0 {
-		path := r.path[1:] + "/" + service.Name
+		path := r.path[1:] + "/" + service.Name + "/"
 		_, err = r.client.KV().DeleteTree(path, nil)
 	}
 	return err


### PR DESCRIPTION
Since DeleteTree actually behaves as a DeletePrefix it will delete everything in Consul's kv store that starts with the given key, so deleting <service-foo> will also delete <service-foo-bar>
Also includes updated Dockerfile and Dockerfile-dev since otherwise it's impossible to build registrator/it's dependencies.